### PR TITLE
Add support of Devanagari, Bengali, Tamil, Telugu, Tibetan

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,13 @@
     "emoji",
     "abugida",
     "brahmic",
+    "devanagari",
     "khmer",
     "lao",
-    "thai",
     "myanmar",
-    "telugu"
+    "telugu",
+    "thai",
+    "tibetan"
   ],
   "files": [
     "README.md",

--- a/package.json
+++ b/package.json
@@ -18,10 +18,12 @@
     "emoji",
     "abugida",
     "brahmic",
+    "bengali",
     "devanagari",
     "khmer",
     "lao",
     "myanmar",
+    "tamil",
     "telugu",
     "thai",
     "tibetan"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,15 @@
     "release": "npm run build && npm run test && npm publish"
   },
   "keywords": [
-    "grapheme", "emoji", "abugida", "brahmic", "khmer", "lao", "thai", "myanmar"
+    "grapheme",
+    "emoji",
+    "abugida",
+    "brahmic",
+    "khmer",
+    "lao",
+    "thai",
+    "myanmar",
+    "telugu"
   ],
   "files": [
     "README.md",

--- a/src/bengali.js
+++ b/src/bengali.js
@@ -1,0 +1,6 @@
+// spec: https://www.unicode.org/charts/PDF/U0980.pdf
+
+const letter = '[\\u{0980}-\\u{09FF}]'
+const trailingLetter = '[\\u{0980}-\\u{0983}\\u{09BC}-\\u{09D7}\\u{09E2}\\u{09E3}\\u{09FE}]'
+const control = '\\u{09CD}' // Virama
+export const bengali = `${letter}(${control}${letter}|${trailingLetter})*`

--- a/src/devanagari.js
+++ b/src/devanagari.js
@@ -1,0 +1,6 @@
+// spec: https://www.unicode.org/charts/PDF/U0900.pdf
+
+const letter = '[\\u{0900}-\\u{097F}]'
+const trailingLetter = '[\\u{0900}-\\u{0903}\\u{093A}-\\u{0957}\\u{0962}\\u{0963}]'
+const control = '\\u{094D}' // Virama
+export const devanagari = `${letter}(${control}${letter}|${trailingLetter})*`

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,15 @@
+import {devanagari} from './devanagari'
 import {khmer} from './khmer'
 import {lao} from './lao'
 import {myanmar} from './myanmar'
+import {telugu} from './telugu'
 import {thai} from './thai'
+import {tibetan} from './tibetan'
 import {countryFlag, keyCap, emojiVariation} from './emoji'
 
 const patterns = [
   countryFlag, keyCap, emojiVariation,
-  khmer, thai, lao, myanmar,
+  devanagari, khmer, lao, myanmar, telugu, thai, tibetan,
   '.'
 ]
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
+import {bengali} from './bengali'
 import {devanagari} from './devanagari'
 import {khmer} from './khmer'
 import {lao} from './lao'
 import {myanmar} from './myanmar'
+import {tamil} from './tamil'
 import {telugu} from './telugu'
 import {thai} from './thai'
 import {tibetan} from './tibetan'
@@ -9,7 +11,7 @@ import {countryFlag, keyCap, emojiVariation} from './emoji'
 
 const patterns = [
   countryFlag, keyCap, emojiVariation,
-  devanagari, khmer, lao, myanmar, telugu, thai, tibetan,
+  bengali, devanagari, khmer, lao, myanmar, tamil, telugu, thai, tibetan,
   '.'
 ]
 

--- a/src/tamil.js
+++ b/src/tamil.js
@@ -1,0 +1,6 @@
+// spec: https://www.unicode.org/charts/PDF/U0B80.pdf
+
+const letter = '[\\u{0B80}-\\u{0BFF}]'
+const trailingLetter = '[\\u{0B82}-\\u{0B83}\\u{0BBE}-\\u{0BD7}\\u{0962}\\u{0963}]'
+// tamil's virama does not combine the following consonant
+export const tamil = `${letter}${trailingLetter}*`

--- a/src/telugu.js
+++ b/src/telugu.js
@@ -1,0 +1,6 @@
+// spec: https://www.unicode.org/charts/PDF/U0C00.pdf
+
+const letter = '[\\u{0C00}-\\u{0C7F}]'
+const trailingLetter = '[\\u{0C00}-\\u{0C04}\\u{0C3E}-\\u{0C56}\\u{0C62}\\u{0C63}]'
+const control = '\\u{0C4D}'
+export const telugu = `${letter}(${control}${letter}|${trailingLetter})*`

--- a/src/telugu.js
+++ b/src/telugu.js
@@ -2,5 +2,5 @@
 
 const letter = '[\\u{0C00}-\\u{0C7F}]'
 const trailingLetter = '[\\u{0C00}-\\u{0C04}\\u{0C3E}-\\u{0C56}\\u{0C62}\\u{0C63}]'
-const control = '\\u{0C4D}'
+const control = '\\u{0C4D}' // Virama
 export const telugu = `${letter}(${control}${letter}|${trailingLetter})*`

--- a/src/tibetan.js
+++ b/src/tibetan.js
@@ -1,0 +1,5 @@
+// spec: https://www.unicode.org/charts/PDF/U0F00.pdf
+
+const letter = '[\\u{0F00}-\\u{0FFF}]'
+const trailingLetter = '[\\0F35\\0F37\\0F39\\0F3E\\0F3F\\u{0F71}-\\u{0F87}\\u{0F8D}-\\u{0FBC}\\u{0FC6}]'
+export const tibetan = `${letter}${trailingLetter}*`

--- a/src/tibetan.js
+++ b/src/tibetan.js
@@ -1,5 +1,5 @@
 // spec: https://www.unicode.org/charts/PDF/U0F00.pdf
 
 const letter = '[\\u{0F00}-\\u{0FFF}]'
-const trailingLetter = '[\\0F35\\0F37\\0F39\\0F3E\\0F3F\\u{0F71}-\\u{0F87}\\u{0F8D}-\\u{0FBC}\\u{0FC6}]'
+const trailingLetter = '[\\0F18\\0F19\\0F35\\0F37\\0F39\\0F3E\\0F3F\\u{0F71}-\\u{0F87}\\u{0F8D}-\\u{0FBC}\\u{0FC6}]'
 export const tibetan = `${letter}${trailingLetter}*`

--- a/test/bengali.js
+++ b/test/bengali.js
@@ -1,0 +1,13 @@
+/* eslint-env mocha */
+
+import {bengali} from '../src/bengali'
+import {testBreak} from './helper'
+
+describe('WordBreakBengali', function () {
+  it('break correctly', function () {
+    const regExp = new RegExp(bengali, 'gu')
+    testBreak(regExp, 'দ্ধ', ['দ্ধ'])
+    testBreak(regExp, 'স্ত্র', ['স্ত্র'])
+    testBreak(regExp, 'নমস্কার', ['ন', 'ম', 'স্কা', 'র'])
+  })
+})

--- a/test/devanagari.js
+++ b/test/devanagari.js
@@ -1,0 +1,13 @@
+/* eslint-env mocha */
+
+import {devanagari} from '../src/devanagari'
+import {testBreak} from './helper'
+
+describe('WordBreakDevanagari', function () {
+  it('break correctly', function () {
+    const regExp = new RegExp(devanagari, 'gu')
+    testBreak(regExp, 'वाह', ['वा', 'ह'])
+    testBreak(regExp, 'शुभ', ['शु', 'भ'])
+    testBreak(regExp, 'रात्रि', ['रा', 'त्रि'])
+  })
+})

--- a/test/tamil.js
+++ b/test/tamil.js
@@ -3,7 +3,7 @@
 import {tamil} from '../src/tamil'
 import {testBreak} from './helper'
 
-describe('WordBreakBengali', function () {
+describe('WordBreakTamil', function () {
   it('break correctly', function () {
     const regExp = new RegExp(tamil, 'gu')
     testBreak(regExp, 'ஹலோ', ['ஹ', 'லோ'])

--- a/test/tamil.js
+++ b/test/tamil.js
@@ -1,0 +1,13 @@
+/* eslint-env mocha */
+
+import {tamil} from '../src/tamil'
+import {testBreak} from './helper'
+
+describe('WordBreakBengali', function () {
+  it('break correctly', function () {
+    const regExp = new RegExp(tamil, 'gu')
+    testBreak(regExp, 'ஹலோ', ['ஹ', 'லோ'])
+    testBreak(regExp, 'குடீவ்னிங்', ['கு', 'டீ', 'வ்', 'னி', 'ங்'])
+    testBreak(regExp, 'ஓக்கே', ['ஓ', 'க்', 'கே'])
+  })
+})

--- a/test/telugu.js
+++ b/test/telugu.js
@@ -1,0 +1,13 @@
+/* eslint-env mocha */
+
+import {telugu} from '../src/telugu'
+import {testBreak} from './helper'
+
+describe('WordBreakTelugu', function () {
+  it('break correctly', function () {
+    const regExp = new RegExp(telugu, 'gu')
+    testBreak(regExp, 'నమస్కారం', ['న', 'మ', 'స్కా', 'రం'])
+    testBreak(regExp, 'పుట్టపర్తి', ['పు', 'ట్ట', 'ప', 'ర్తి'])
+    testBreak(regExp, 'ఉన్నారు', ['ఉ', 'న్నా', 'రు'])
+  })
+})

--- a/test/tibetan.js
+++ b/test/tibetan.js
@@ -1,0 +1,11 @@
+/* eslint-env mocha */
+
+import {tibetan} from '../src/tibetan'
+import {testBreak} from './helper'
+
+describe('WordBreakTibetan', function () {
+  it('break correctly', function () {
+    const regExp = new RegExp(tibetan, 'gu')
+    testBreak(regExp, 'བསྟན་འཛིན་རྒྱ་མཚོ།', ['བ', 'སྟ', 'ན', '་', 'འ', 'ཛི', 'ན', '་', 'རྒྱ', '་', 'མ', 'ཚོ', '།'])
+  })
+})

--- a/test/tibetan.js
+++ b/test/tibetan.js
@@ -6,6 +6,7 @@ import {testBreak} from './helper'
 describe('WordBreakTibetan', function () {
   it('break correctly', function () {
     const regExp = new RegExp(tibetan, 'gu')
-    testBreak(regExp, 'བསྟན་འཛིན་རྒྱ་མཚོ།', ['བ', 'སྟ', 'ན', '་', 'འ', 'ཛི', 'ན', '་', 'རྒྱ', '་', 'མ', 'ཚོ', '།'])
+    testBreak(regExp, 'གཟིགས་དང་', ['ག', 'ཟི', 'ག', 'ས', '་', 'ད', 'ང', '་'])
+    testBreak(regExp, 'ལགས་མིན་', ['ལ', 'ག', 'ས', '་', 'མི', 'ན', '་'])
   })
 })


### PR DESCRIPTION
We had support of many east asian characters.

Now we add some support of characters used in India.

- devanagari  (used in Hindi, Marathi, etc.)
- bengali
- tamil
- telugu

Based on the demographic of Indian language, 
https://www.mapsofindia.com/culture/indian-languages.html
I guess we have supported approximately 70% of the population.
So I hope we could cover most of  this request:
https://github.com/nota/split-graphemes/issues/4

Plus, I added support of Tibetan. 

All characters added in this pull request are categorized as Brahminic (Indic) script = Abugida.

