### PR TITLE
build -> test -> publish by npm prepublish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,5 +15,4 @@ jobs:
       - run: 'npm -v'
       - checkout
       - run: 'npm ci'
-      - run: 'npm run build'
-      - run: 'npm run test'
+      - run: 'npm test'

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "build": "run-s build:*",
     "build:clean": "if test -d ./lib; then rm -r ./lib; fi",
     "build:babel": "babel src/ --out-dir lib/",
-    "watch": "npm run build -- --watch",
     "pretest": "npm run build",
     "test": "run-s test:*",
     "test:standard": "standard",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "run-s build:*",
     "build:clean": "if test -d ./lib; then rm -r ./lib; fi",
-    "build:babel": "babel src/ --out-dir lib/ --minified",
+    "build:babel": "babel src/ --out-dir lib/",
     "watch": "npm run build -- --watch",
     "pretest": "npm run build",
     "test": "run-s test:*",

--- a/package.json
+++ b/package.json
@@ -8,10 +8,11 @@
     "build:clean": "if test -d ./lib; then rm -r ./lib; fi",
     "build:babel": "babel src/ --out-dir lib/ --minified",
     "watch": "npm run build -- --watch",
+    "pretest": "npm run build",
     "test": "run-s test:*",
     "test:standard": "standard",
     "test:mocha": "mocha test/*.js -r babel-register -r babel-polyfill --timeout 20000 --exit",
-    "release": "npm run build && npm run test && npm publish"
+    "prepublishOnly": "npm test"
   },
   "keywords": [
     "grapheme",

--- a/test/bengali.js
+++ b/test/bengali.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import { bengali } from '../src/bengali'
+import { bengali } from '../lib/bengali'
 import { testBreak } from './helper'
 
 describe('WordBreakBengali', function () {

--- a/test/devanagari.js
+++ b/test/devanagari.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import { devanagari } from '../src/devanagari'
+import { devanagari } from '../lib/devanagari'
 import { testBreak } from './helper'
 
 describe('WordBreakDevanagari', function () {

--- a/test/emoji.js
+++ b/test/emoji.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import { emojiVariation, keyCap, countryFlag } from '../src/emoji'
+import { emojiVariation, keyCap, countryFlag } from '../lib/emoji'
 import { testBreak } from './helper'
 
 describe('WordBreakEmoji', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 
 import { assert } from 'chai'
-import { splitGraphemes } from '../lib/'
+import { splitGraphemes } from '../'
 
 function testBreak (source, results) {
   const res = splitGraphemes(source)

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 
 import { assert } from 'chai'
-import { splitGraphemes } from '../src/'
+import { splitGraphemes } from '../lib/'
 
 function testBreak (source, results) {
   const res = splitGraphemes(source)

--- a/test/khmer.js
+++ b/test/khmer.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import { khmer } from '../src/khmer'
+import { khmer } from '../lib/khmer'
 import { testBreak } from './helper'
 
 describe('WordBreakKhmer', function () {

--- a/test/lao.js
+++ b/test/lao.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import { lao } from '../src/lao'
+import { lao } from '../lib/lao'
 import { testBreak } from './helper'
 
 describe('WordBreakLao', function () {

--- a/test/myanmar.js
+++ b/test/myanmar.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import { myanmar } from '../src/myanmar'
+import { myanmar } from '../lib/myanmar'
 import { testBreak } from './helper'
 
 describe('WordBreakMyanmar', function () {

--- a/test/tamil.js
+++ b/test/tamil.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import { tamil } from '../src/tamil'
+import { tamil } from '../lib/tamil'
 import { testBreak } from './helper'
 
 describe('WordBreakTamil', function () {

--- a/test/telugu.js
+++ b/test/telugu.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import { telugu } from '../src/telugu'
+import { telugu } from '../lib/telugu'
 import { testBreak } from './helper'
 
 describe('WordBreakTelugu', function () {

--- a/test/thai.js
+++ b/test/thai.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import { thai } from '../src/thai'
+import { thai } from '../lib/thai'
 import { testBreak } from './helper'
 
 describe('WordBreakThai', function () {

--- a/test/tibetan.js
+++ b/test/tibetan.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import { tibetan } from '../src/tibetan'
+import { tibetan } from '../lib/tibetan'
 import { testBreak } from './helper'
 
 describe('WordBreakTibetan', function () {


### PR DESCRIPTION
https://scrapbox.io/Nota/npm_prepublishでtestとbuildを確認してから、publishする

- Run `npm run build` and `npm test` each time before `npm publish`
- changed test target from `src/` to `lib/`
  - It is necessary to test the code to be published, instead of the source code.
