### PR TITLE
npm publish then git push

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "run-s test:*",
     "test:standard": "standard",
     "test:mocha": "mocha test/*.js -r @babel/register -r @babel/polyfill --exit",
-    "prepublishOnly": "npm test"
+    "prepublishOnly": "npm test",
+    "postpublish": "git push origin --tags && git push origin master"
   },
   "keywords": [
     "grapheme",


### PR DESCRIPTION
Automatically execute "git push" after "npm publish"

## problem

After running npm publish, I forgot to push the release-tag and master branch to github.

## solution

use "postpublish"

https://docs.npmjs.com/misc/scripts
> publish, postpublish: Run AFTER the package is published.

Just run npm publish, it will run in the order of build → test → npm publish → git push

### in @notainc/delay

We already use git push using postpublish
https://github.com/nota/delay/blob/master/package.json

[![Screenshot from Gyazo](https://gyazo.com/edec3e86c3252e232d7dbc2082cb8d40/raw)](https://gyazo.com/edec3e86c3252e232d7dbc2082cb8d40)