### PR TITLE
Treat U+0E33 as trailingLetter

### DIFF
--- a/src/thai.js
+++ b/src/thai.js
@@ -1,5 +1,5 @@
 // spec: https://www.unicode.org/charts/PDF/U0E00.pdf
 
 const letter = '[\\u0E00-\\u0E7F]'
-const trailingLetter = '[\\u0E31\\u0E34-\\u0E3A\\u0E47-\\u0E4E]'
+const trailingLetter = '[\\u0E31\\u0E33-\\u0E3A\\u0E47-\\u0E4E]'
 export const thai = `${letter}${trailingLetter}*`

--- a/test/thai.js
+++ b/test/thai.js
@@ -8,5 +8,6 @@ describe('WordBreakThai', function () {
     const regExp = new RegExp(thai, 'gu')
     testBreak(regExp, 'ไม้ทัณฑฆาต', ['ไ', 'ม้', 'ทั', 'ณ', 'ฑ', 'ฆ', 'า', 'ต'])
     testBreak(regExp, 'ข้าวมันไก่', ['ข้', 'า', 'ว', 'มั', 'น', 'ไ', 'ก่'])
+    testBreak(regExp, 'ลำแสง', ['ลำ', 'แ', 'ส', 'ง'])
   })
 })


### PR DESCRIPTION
Treat " ำ" (U+0E33) as trailingLetter.
https://www.compart.com/en/unicode/U+0E33