### PR TITLE
support black cat emoji

### DIFF
--- a/src/emoji.js
+++ b/src/emoji.js
@@ -8,6 +8,7 @@ export const keyCap = '[0-9#\\*][\\u{FE0F}]?\\u{20E3}'
 const emojiRange = [
   '[\\u{2600}-\\u{26FF}]', // Miscellaneous Symbols
   '[\\u{2700}-\\u{27BF}]', // Dingbats
+  '[\\u{2B00}-\\u{2BFF}]', // Miscellaneous Symbols and Arrows
   '[\\u{1F300}-\\u{1F5FF}]', // Miscellaneous Symbols and Pictographs
   '[\\u{1F600}-\\u{1F64F}]', // Emoticons
   '[\\u{1F680}-\\u{1F6FF}]', // Transport and Map Symbols

--- a/test/emoji.js
+++ b/test/emoji.js
@@ -60,5 +60,9 @@ describe('WordBreakEmoji', function () {
       testBreak(regExp, '☎☎️', ['☎', '☎️'])
       testBreak(regExp, '🤜🏾🤘🏾', ['🤜🏾', '🤘🏾'])
     })
+
+    it('blackcat', function () {
+      testBreak(regExp, '🐈‍⬛', ['🐈‍⬛'])
+    })
   })
 })


### PR DESCRIPTION
This pr fixes the issue on black-cat emoji `🐈‍⬛` https://emojipedia.org/black-cat/.
expected behavior:
```js
splitGraphemes("🐈‍⬛") // ["🐈‍⬛"]
```
actual behavior:
```js
splitGraphemes("🐈‍⬛") // ["🐈", "", "⬛️"], 🐈 + ZWJ + ⬛️
```

The ⬛️ is U+2B1B included in [Miscellaneous Symbols and Arrows](https://en.wikipedia.org/wiki/Miscellaneous_Symbols_and_Arrows), so I add the range U+2B00..U+2BFF as a part of emoji.
